### PR TITLE
Updated build versions of Node.js

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x, 24.x]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## :recycle: Current situation

The build script was building against Node.js v18, 20, and 22.

## :bulb: Proposed solution

Updated the build script was building against Node.js v20, 22, and 24.
