### PR TITLE
Ensure storage directory exists before writing status files

### DIFF
--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,10 +1,12 @@
 import { promises as fs } from 'fs';
+import * as path from 'path';
 
 export class Storage {
     public constructor(private readonly filePath: string) {
     }
 
     public async write<T>(data: Record<string, T>): Promise<void> {
+        await fs.mkdir(path.dirname(this.filePath), { recursive: true });
         await fs.writeFile(this.filePath, JSON.stringify(data), 'utf8');
     }
 


### PR DESCRIPTION
Fixes #328 

The plugin attempts to write per-radio status JSON files to `/home/homebridge/.homebridge/@homebridge-plugins/<uuid>.status.json` but does not create the parent directory if it doesn't exist. On a fresh Homebridge install (bare-metal apt-based), `@homebridge-plugins/` is not pre-created, so every state write throws ENOENT and the unhandled exception causes Homebridge to restart.

This patch adds `fs.mkdir(path.dirname(this.filePath), { recursive: true })` before `writeFile` in `Storage.write()`. With `recursive: true`, the call is a no-op when the directory exists, so it has no impact on already-working installs.

Tested on Raspberry Pi OS Bookworm with Homebridge v1.11.4 and Node.js v24.15.0.
