### PR TITLE
feat: optional keepConnectionWarm for low-latency audio buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,34 @@ For Whom The Bell Tolls.mp3
 > [!NOTE]
 > Comments starting with `#` and empty lines are ignored.
 
+### Low-latency audio buttons (`keepConnectionWarm`)
+
+By default, every audio-file button press starts a fresh `python3` helper that
+imports pyatv and re-establishes the AirPlay connection before any sound plays.
+For short sound effects (door chimes, alerts, ringtones) that startup cost
+dominates the perceived delay.
+
+Enabling `keepConnectionWarm` starts a single, long-lived pyatv worker when the
+plugin launches (only if at least one `audioFiles` entry is configured). The
+worker imports pyatv once and holds the connection open, so subsequent button
+presses skip the cold start and play noticeably sooner.
+
+```
+    "keepConnectionWarm": true
+```
+
+Notes:
+
+- Default is `false`, preserving the original spawn-per-press behavior.
+- If the warm worker is unavailable for any reason, playback automatically falls
+  back to the standard spawn path, so a worker failure never silently breaks a
+  button.
+- The warm path applies to the HomeKit **audio-file switch accessories**. The
+  webhook (`/play/...`) endpoint is unaffected and continues to use the standard
+  path.
+- The first press after restart may still be slightly slower while the worker
+  finishes its initial warm-up.
+
 ### Webhook for audio file playback
 
 You should use the Homebridge server name (default for Homebridge server is homebridge.local) or IP to invoke playback via URL

--- a/README.md
+++ b/README.md
@@ -161,31 +161,34 @@ For Whom The Bell Tolls.mp3
 > [!NOTE]
 > Comments starting with `#` and empty lines are ignored.
 
-### Low-latency audio buttons (`keepConnectionWarm`)
+### Low-latency audio buttons
 
 By default, every audio-file button press starts a fresh `python3` helper that
 imports pyatv and re-establishes the AirPlay connection before any sound plays.
 For short sound effects (door chimes, alerts, ringtones) that startup cost
 dominates the perceived delay.
 
-Enabling `keepConnectionWarm` starts a single, long-lived pyatv worker when the
-plugin launches (only if at least one `audioFiles` entry is configured). The
-worker imports pyatv once and holds the connection open, so subsequent button
-presses skip the cold start and play noticeably sooner.
+To avoid it, the plugin keeps a single, long-lived pyatv worker running. The
+worker imports pyatv once and holds the connection open, so button presses skip
+the cold start and play noticeably sooner. This is **on by default** and is only
+started when at least one `audioFiles` entry is configured, so installs without
+audio buttons consume no extra resources.
+
+If you ever want to disable it (and fall back to the original spawn-per-press
+behavior), set `keepConnectionWarm` to `false` in your config:
 
 ```
-    "keepConnectionWarm": true
+    "keepConnectionWarm": false
 ```
 
 Notes:
 
-- Default is `false`, preserving the original spawn-per-press behavior.
-- If the warm worker is unavailable for any reason, playback automatically falls
-  back to the standard spawn path, so a worker failure never silently breaks a
-  button.
 - The warm path applies to the HomeKit **audio-file switch accessories**. The
   webhook (`/play/...`) endpoint is unaffected and continues to use the standard
   path.
+- If the warm worker is unavailable for any reason, playback automatically falls
+  back to the standard spawn path, so a worker failure never silently breaks a
+  button.
 - The first press after restart may still be slightly slower while the worker
   finishes its initial warm-up.
 

--- a/bin/warm-worker.py
+++ b/bin/warm-worker.py
@@ -1,0 +1,208 @@
+# !/usr/bin/python3
+"""Resident pyatv worker for homebridge-homepod-radio (warm-connection mode).
+
+Spawned once by the plugin when ``keepConnectionWarm`` is enabled. It imports
+pyatv a single time, scans for and connects to the HomePod once, and then holds
+that connection warm, reusing it for every audio-button press. This eliminates
+the ~5 s per-press cost (``import pyatv`` cold start + device scan + connect)
+that ``stream.py`` pays each time it is spawned fresh.
+
+Protocol (newline-delimited JSON; one object per line):
+
+    stdin   {"id": "<id>", "cmd": "play", "file": "<abs path>",
+             "volume": <0-100>, "title": "<text>"}
+            {"id": "<id>", "cmd": "ping"}
+
+    stdout  {"event": "ready"}                       (once, after startup)
+            {"id": "<id>", "ok": true}
+            {"id": "<id>", "ok": false, "error": "..."}
+
+All human-readable logging goes to **stderr** so that stdout stays a clean
+protocol channel. ``volume`` of 0 (or missing) means "do not change volume",
+matching the existing ``stream.py`` semantics.
+"""
+import argparse
+import asyncio
+import json
+import logging
+import os
+import re
+import sys
+
+import pyatv
+from pyatv.const import Protocol
+from pyatv.interface import MediaMetadata
+
+
+_LOGGER = logging.getLogger("warm-worker")
+
+
+def _out(obj) -> None:
+    """Write one protocol message to stdout and flush immediately."""
+    sys.stdout.write(json.dumps(obj) + "\n")
+    sys.stdout.flush()
+
+
+class WarmConnection:
+    """Owns a single, reused pyatv connection to the target device."""
+
+    def __init__(self, identifier: str, loop: asyncio.AbstractEventLoop) -> None:
+        self.identifier = identifier
+        self.loop = loop
+        self.atv = None
+        self._lock = asyncio.Lock()
+
+    async def _scan(self):
+        # Mirror stream.py: scan by 12-hex id / MAC first, else by RAOP name.
+        ident_regex = re.compile(r"^[0-9A-Fa-f]{12}$")
+        mac_regex = re.compile(r"^[0-9A-Fa-f]{2}(:[0-9A-Fa-f]{2}){5}$")
+        atvs = []
+        if (len(self.identifier) == 12 and ident_regex.match(self.identifier)) or mac_regex.match(
+            self.identifier
+        ):
+            _LOGGER.info("scanning by id/MAC: %s", self.identifier)
+            atvs = await pyatv.scan(self.loop, identifier=self.identifier, timeout=5)
+        if not atvs:
+            _LOGGER.info("scanning by name: %s", self.identifier)
+            found = await pyatv.scan(self.loop, protocol=Protocol.RAOP, timeout=5)
+            atvs = [a for a in found if a.name == self.identifier]
+        if not atvs:
+            raise RuntimeError("device not found: %s" % self.identifier)
+        return atvs[0]
+
+    async def ensure_connected(self):
+        if self.atv is not None:
+            return self.atv
+        conf = await self._scan()
+        _LOGGER.info("connecting to %s", conf.address)
+        self.atv = await pyatv.connect(conf, self.loop)
+        _LOGGER.info("connected; holding connection warm")
+        return self.atv
+
+    def close(self) -> None:
+        if self.atv is not None:
+            try:
+                self.atv.close()
+            except Exception:  # noqa: BLE001 - best-effort teardown
+                pass
+            self.atv = None
+
+    async def _expand(self, file_path: str):
+        # Mirror stream.py m3u/m3u8 handling so warm playback matches spawn.
+        if file_path.endswith(".m3u") or file_path.endswith(".m3u8"):
+            folder = os.path.dirname(file_path)
+            with open(file_path, "r", encoding="UTF-8") as playlist:
+                lines = [ln.strip() for ln in playlist if ln.strip()]
+            return [
+                os.path.join(folder, ln)
+                for ln in lines
+                if re.match(r"^[A-Za-z0-9]", ln)
+                and not re.match(r"^[A-Za-z]:\\", ln)
+                and not re.match(r"^http[s]?://", ln)
+            ]
+        return [file_path]
+
+    async def play(self, file_path: str, volume, title: str) -> None:
+        """Stream a file (or m3u) on the warm connection, reconnecting once on error."""
+        async with self._lock:
+            last_err = None
+            for attempt in (1, 2):
+                try:
+                    atv = await self.ensure_connected()
+                    if volume and int(volume) > 0:
+                        try:
+                            await atv.audio.set_volume(float(volume))
+                        except Exception as ex:  # noqa: BLE001
+                            _LOGGER.warning("set_volume(%s) failed: %s", volume, ex)
+                    metadata = MediaMetadata(title=title, album=title, artist=None, artwork=None)
+                    for song in await self._expand(file_path):
+                        _LOGGER.info("streaming %s (attempt %d)", song, attempt)
+                        await atv.stream.stream_file(song, metadata)
+                    _LOGGER.info("finished streaming %s", file_path)
+                    return
+                except Exception as ex:  # noqa: BLE001
+                    last_err = ex
+                    _LOGGER.error("stream attempt %d failed: %s", attempt, ex)
+                    self.close()  # force a fresh connect on retry
+            raise last_err if last_err is not None else RuntimeError("play failed")
+
+
+async def _read_line(loop: asyncio.AbstractEventLoop) -> str:
+    # Blocking stdin read offloaded to a thread so the asyncio loop stays free.
+    return await loop.run_in_executor(None, sys.stdin.readline)
+
+
+async def main_async(identifier: str) -> None:
+    loop = asyncio.get_running_loop()
+    conn = WarmConnection(identifier, loop)
+
+    # Best-effort warmup; a failure here is non-fatal because the first play
+    # will retry the scan/connect itself.
+    try:
+        await conn.ensure_connected()
+    except Exception as ex:  # noqa: BLE001
+        _LOGGER.warning("initial warmup failed (will retry on first play): %s", ex)
+
+    _out({"event": "ready"})
+
+    while True:
+        line = await _read_line(loop)
+        if line == "":  # EOF: parent closed our stdin
+            _LOGGER.info("stdin closed, exiting")
+            break
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except Exception:  # noqa: BLE001
+            _LOGGER.warning("ignoring non-JSON line: %s", line)
+            continue
+
+        req_id = msg.get("id")
+        cmd = msg.get("cmd")
+
+        if cmd == "ping":
+            _out({"id": req_id, "ok": True, "pong": True})
+            continue
+
+        if cmd == "play":
+            file_path = msg.get("file")
+            volume = msg.get("volume", 0)
+            title = msg.get("title") or (os.path.basename(file_path) if file_path else "")
+            if not file_path:
+                _out({"id": req_id, "ok": False, "error": "missing file"})
+                continue
+            try:
+                await conn.play(file_path, volume, title)
+                _out({"id": req_id, "ok": True})
+            except Exception as ex:  # noqa: BLE001
+                _out({"id": req_id, "ok": False, "error": str(ex)})
+            continue
+
+        _out({"id": req_id, "ok": False, "error": "unknown cmd: %s" % cmd})
+
+    conn.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-i", "--id", dest="id", required=True, help="device identifier")
+    parser.add_argument("-v", "--verbose", action="store_true", dest="verbose")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        stream=sys.stderr,
+        datefmt="%Y-%m-%d %H:%M:%S",
+        format="%(asctime)s %(levelname)s [%(name)s]: %(message)s",
+    )
+
+    try:
+        asyncio.run(main_async(args.id))
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/config.schema.json
+++ b/config.schema.json
@@ -67,6 +67,13 @@
                 "default": false,
                 "required": false
             },
+            "keepConnectionWarm": {
+                "title": "Keep AirPlay Connection Warm",
+                "description": "Hold a single pyatv connection to the HomePod open and reuse it for audio buttons, eliminating the multi-second cold-start delay on each press. Recommended when you use audio buttons.",
+                "type": "boolean",
+                "default": false,
+                "required": false
+            },
             "audioFiles": {
                 "title": "Audio Buttons",
                 "type": "array",

--- a/config.schema.json
+++ b/config.schema.json
@@ -67,13 +67,6 @@
                 "default": false,
                 "required": false
             },
-            "keepConnectionWarm": {
-                "title": "Keep AirPlay Connection Warm",
-                "description": "Hold a single pyatv connection to the HomePod open and reuse it for audio buttons, eliminating the multi-second cold-start delay on each press. Recommended when you use audio buttons.",
-                "type": "boolean",
-                "default": false,
-                "required": false
-            },
             "audioFiles": {
                 "title": "Audio Buttons",
                 "type": "array",

--- a/src/lib/airplayDevice.ts
+++ b/src/lib/airplayDevice.ts
@@ -1,6 +1,7 @@
 import { Logger } from 'homebridge';
 
 import { delay } from './promises.js';
+import { WarmPlayer } from './warmPlayer.js';
 
 import * as child from 'child_process';
 import * as path from 'path';
@@ -24,6 +25,7 @@ export class AirPlayDevice {
         'https://www.apple.com/v/apple-music/q/images/shared/og__ckjrh2mu8b2a_image.png';
 
     private streaming: child.ChildProcess | undefined;
+    private warmPlaying = false;
     private lastSeen!: number;
     private heartbeat: ReturnType<typeof setInterval> | undefined;
     private streamingRetries = 0;
@@ -39,6 +41,7 @@ export class AirPlayDevice {
         private readonly streamerName: string,
         private readonly streamMetadataUrl?: string,
         private readonly streamArtworkUrl?: string,
+        private readonly warmPlayer?: WarmPlayer,
     ) {
         this.debug = this.verboseMode ? this.logger.info.bind(this.logger) : this.logger.debug.bind(this.logger);
         this.pluginPath = path.resolve(path.dirname(__filename), '..', '..');
@@ -63,6 +66,25 @@ export class AirPlayDevice {
     }
 
     public async playFile(filePath: string, volume: number): Promise<boolean> {
+        // Prefer the shared warm worker (held pyatv connection) when available,
+        // falling back to the per-press spawn path below if it is down or fails.
+        if (this.warmPlayer && this.warmPlayer.isReady()) {
+            this.warmPlaying = true;
+            this.logger.info(`[${this.streamerName}] Started file streaming ${filePath} (warm)`);
+            try {
+                const ok = await this.warmPlayer.playFile(filePath, volume, this.streamerName);
+                this.warmPlaying = false;
+                if (ok) {
+                    this.debug(`[${this.streamerName}] Finished file streaming ${filePath} (warm)`);
+                    return true;
+                }
+                this.logger.warn(`[${this.streamerName}] Warm play failed, falling back to spawn`);
+            } catch (err) {
+                this.warmPlaying = false;
+                this.logger.warn(`[${this.streamerName}] Warm play error, falling back to spawn: ${err}`);
+            }
+        }
+
         // create pipe for the command:
         const scriptPath = path.resolve(path.dirname(__filename), '..', 'stream.py');
 
@@ -239,6 +261,7 @@ export class AirPlayDevice {
 
     private async endStreaming(streamExited: boolean = false): Promise<boolean> {
         try {
+            this.warmPlaying = false;
             if (this.streaming === undefined) {
                 this.debug(`[${this.streamerName}] End streaming: streaming: ${this.streaming}`);
                 return Promise.resolve(true);
@@ -272,6 +295,6 @@ export class AirPlayDevice {
     }
 
     public isPlaying(): boolean {
-        return !!this.streaming;
+        return !!this.streaming || this.warmPlaying;
     }
 }

--- a/src/lib/warmPlayer.ts
+++ b/src/lib/warmPlayer.ts
@@ -1,0 +1,198 @@
+import { Logger } from 'homebridge';
+
+import * as child from 'child_process';
+import * as path from 'path';
+import * as readline from 'readline';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+
+interface PendingRequest {
+    resolve: (ok: boolean) => void;
+    timer: ReturnType<typeof setTimeout>;
+}
+
+/**
+ * Supervises a single resident `warm-worker.py` process that holds one warm
+ * pyatv connection to the HomePod and replays audio files on it. Shared by all
+ * audio-button accessories for a given homepodId.
+ *
+ * The worker is spawned once and kept alive; if it crashes it is restarted with
+ * exponential backoff. Each play is a newline-delimited JSON request/response on
+ * the worker's stdin/stdout (logs come back on stderr). When the worker is not
+ * ready, `playFile()` resolves `false` so the caller can fall back to the
+ * original per-press spawn path — behavior degrades gracefully.
+ */
+export class WarmPlayer {
+    private worker: child.ChildProcess | undefined;
+    private rl: readline.Interface | undefined;
+    private ready = false;
+    private stopped = false;
+
+    private restartDelay = 1000;
+    private readonly MAX_RESTART_DELAY = 30000;
+    private readonly PLAY_TIMEOUT_MS = 60000;
+
+    private nextId = 1;
+    private readonly pending = new Map<string, PendingRequest>();
+
+    private readonly scriptPath: string;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    private readonly debug: (message: string, ...parameters: any[]) => void;
+
+    constructor(
+        private readonly homepodId: string,
+        private readonly logger: Logger,
+        private readonly verboseMode: boolean,
+    ) {
+        this.debug = this.verboseMode ? this.logger.info.bind(this.logger) : this.logger.debug.bind(this.logger);
+        // dist/lib/warmPlayer.js -> ../warm-worker.py == dist/warm-worker.py
+        this.scriptPath = path.resolve(path.dirname(__filename), '..', 'warm-worker.py');
+    }
+
+    public start(): void {
+        if (this.stopped || this.worker) {
+            return;
+        }
+
+        const args = ['-u', this.scriptPath, '--id', this.homepodId];
+        if (this.verboseMode) {
+            args.push('--verbose');
+        }
+        this.logger.info(`[warm] starting worker: python3 ${args.join(' ')}`);
+
+        this.worker = child.spawn('python3', args, { env: { ...process.env } });
+
+        this.rl = readline.createInterface({ input: this.worker.stdout! });
+        this.rl.on('line', (line) => this.handleLine(line));
+
+        this.worker.stderr!.on('data', (data) => {
+            this.debug(`[warm worker] ${data.toString().trim()}`);
+        });
+
+        this.worker.on('error', (err) => {
+            this.logger.error(`[warm] worker spawn error: ${err}`);
+        });
+
+        this.worker.on('exit', (code, signal) => {
+            this.logger.warn(`[warm] worker exited code=${code} signal=${signal}`);
+            this.ready = false;
+            this.rl?.close();
+            this.rl = undefined;
+            this.worker = undefined;
+            this.failAllPending();
+            this.scheduleRestart();
+        });
+    }
+
+    private handleLine(line: string): void {
+        const trimmed = line.trim();
+        if (!trimmed) {
+            return;
+        }
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        let msg: any;
+        try {
+            msg = JSON.parse(trimmed);
+        } catch {
+            this.debug(`[warm] non-JSON from worker: ${trimmed}`);
+            return;
+        }
+
+        if (msg.event === 'ready') {
+            this.ready = true;
+            this.restartDelay = 1000; // healthy start resets backoff
+            this.logger.info('[warm] worker ready (connection held warm)');
+            return;
+        }
+
+        if (msg.id !== undefined && msg.id !== null) {
+            const key = String(msg.id);
+            const pending = this.pending.get(key);
+            if (pending) {
+                clearTimeout(pending.timer);
+                this.pending.delete(key);
+                if (msg.ok === false && msg.error) {
+                    this.logger.warn(`[warm] play failed: ${msg.error}`);
+                }
+                pending.resolve(msg.ok === true);
+            }
+        }
+    }
+
+    private scheduleRestart(): void {
+        if (this.stopped) {
+            return;
+        }
+        const delay = this.restartDelay;
+        this.restartDelay = Math.min(this.restartDelay * 2, this.MAX_RESTART_DELAY);
+        this.logger.info(`[warm] restarting worker in ${delay}ms`);
+        setTimeout(() => this.start(), delay);
+    }
+
+    private failAllPending(): void {
+        for (const pending of this.pending.values()) {
+            clearTimeout(pending.timer);
+            pending.resolve(false);
+        }
+        this.pending.clear();
+    }
+
+    public isReady(): boolean {
+        return this.ready && !!this.worker;
+    }
+
+    /**
+     * Ask the warm worker to play a file. Resolves `true` on success, or `false`
+     * if the worker is unavailable or the play failed, so the caller can fall
+     * back to spawning stream.py.
+     */
+    public playFile(filePath: string, volume: number, title: string): Promise<boolean> {
+        if (!this.isReady()) {
+            return Promise.resolve(false);
+        }
+
+        const id = String(this.nextId++);
+        const payload = JSON.stringify({ id, cmd: 'play', file: filePath, volume, title }) + '\n';
+
+        return new Promise<boolean>((resolve) => {
+            const timer = setTimeout(() => {
+                this.pending.delete(id);
+                this.logger.warn(`[warm] play timed out for ${filePath}`);
+                resolve(false);
+            }, this.PLAY_TIMEOUT_MS);
+
+            this.pending.set(id, { resolve, timer });
+
+            try {
+                this.worker!.stdin!.write(payload);
+            } catch (err) {
+                clearTimeout(timer);
+                this.pending.delete(id);
+                this.logger.warn(`[warm] failed to write to worker: ${err}`);
+                resolve(false);
+            }
+        });
+    }
+
+    public stop(): void {
+        this.stopped = true;
+        this.ready = false;
+        this.failAllPending();
+        if (this.worker) {
+            try {
+                this.worker.stdin?.end();
+            } catch {
+                // ignore
+            }
+            try {
+                this.worker.kill('SIGTERM');
+            } catch {
+                // ignore
+            }
+            this.worker = undefined;
+        }
+        this.rl?.close();
+        this.rl = undefined;
+    }
+}

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -11,6 +11,7 @@ import { HomepodVolumeAccessory } from './platformHomepodVolumeAccessory.js';
 
 import { delay } from './lib/promises.js';
 import { HttpService } from './lib/httpService.js';
+import { WarmPlayer } from './lib/warmPlayer.js';
 
 let hap: HAP;
 
@@ -24,6 +25,7 @@ export class HomepodRadioPlatform implements DynamicPlatformPlugin {
 
     private readonly httpService: HttpService;
     private readonly platformActions: HomepodRadioPlatformWebActions;
+    private warmPlayer: WarmPlayer | undefined;
 
     public readonly Service: typeof Service;
     public readonly Characteristic: typeof Characteristic;
@@ -53,6 +55,19 @@ export class HomepodRadioPlatform implements DynamicPlatformPlugin {
 
         this.api.on('didFinishLaunching', async () => {
             this.logger.info('Finished initializing platform');
+
+            // Start one shared warm worker (held pyatv connection) before adding
+            // audio buttons, so the first press can already use it.
+            if (this.platformConfig.keepConnectionWarm && this.platformConfig.audioFiles.length > 0) {
+                this.logger.info('Platform: keepConnectionWarm enabled - starting warm worker');
+                this.warmPlayer = new WarmPlayer(
+                    this.platformConfig.homepodId,
+                    this.logger,
+                    this.platformConfig.verboseMode,
+                );
+                this.warmPlayer.start();
+            }
+
             this.platformConfig.radios.forEach((radio) => this.addRadioAccessory(radio));
             this.platformConfig.audioFiles.forEach((fileSwitch) => this.addFileSwitchAccessory(fileSwitch));
             await delay(1000, 0);
@@ -71,6 +86,7 @@ export class HomepodRadioPlatform implements DynamicPlatformPlugin {
             if (this.platformConfig.httpPort > 0) {
                 this.httpService.stop();
             }
+            this.warmPlayer?.stop();
         });
     }
 
@@ -127,7 +143,7 @@ export class HomepodRadioPlatform implements DynamicPlatformPlugin {
         // @see https://github.com/homebridge/homebridge/issues/2553#issuecomment-623675893
         accessory.category = Categories.SPEAKER;
 
-        new HomepodAudioSwitchAccessory(this, accessory, fileSwitch, this.playbackController);
+        new HomepodAudioSwitchAccessory(this, accessory, fileSwitch, this.playbackController, this.warmPlayer);
 
         // SmartSpeaker service must be added as an external accessory.
         // @see https://github.com/homebridge/homebridge/issues/2553#issuecomment-622961035

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -57,9 +57,11 @@ export class HomepodRadioPlatform implements DynamicPlatformPlugin {
             this.logger.info('Finished initializing platform');
 
             // Start one shared warm worker (held pyatv connection) before adding
-            // audio buttons, so the first press can already use it.
+            // audio buttons, so the first press can already use it. On by
+            // default, but only when at least one audio button is configured so
+            // installs without audio buttons consume no extra resources.
             if (this.platformConfig.keepConnectionWarm && this.platformConfig.audioFiles.length > 0) {
-                this.logger.info('Platform: keepConnectionWarm enabled - starting warm worker');
+                this.logger.info('Platform: keeping AirPlay connection warm for audio buttons');
                 this.warmPlayer = new WarmPlayer(
                     this.platformConfig.homepodId,
                     this.logger,

--- a/src/platformAudioSwitchAccessory.ts
+++ b/src/platformAudioSwitchAccessory.ts
@@ -7,6 +7,7 @@ import { PLUGIN_MANUFACTURER, PLUGIN_MODEL } from './platformConstants.js';
 
 import { AirPlayDevice } from './lib/airplayDevice.js';
 import { PlaybackController, PlaybackStreamer } from './lib/playbackController.js';
+import { WarmPlayer } from './lib/warmPlayer.js';
 
 import * as os from 'os';
 import * as path from 'path';
@@ -21,6 +22,7 @@ export class HomepodAudioSwitchAccessory implements AccessoryPlugin, PlaybackStr
         private readonly accessory: PlatformAccessory,
         private readonly audioConfig: AudioConfig,
         private readonly playbackController: PlaybackController,
+        private readonly warmPlayer?: WarmPlayer,
     ) {
         this.device = new AirPlayDevice(
             this.platform.platformConfig.homepodId,
@@ -29,6 +31,7 @@ export class HomepodAudioSwitchAccessory implements AccessoryPlugin, PlaybackStr
             this.streamerName(),
             '',
             '',
+            this.warmPlayer,
         );
 
         this.service =

--- a/src/platformConfig.ts
+++ b/src/platformConfig.ts
@@ -32,6 +32,7 @@ export class HomepodRadioPlatformConfig {
 
     public readonly enableVolumeControl: boolean;
     public readonly volume: number;
+    public readonly keepConnectionWarm: boolean;
 
     constructor(private config: PlatformConfig) {
         this.name = config.name || 'HomePod Mini Radio';
@@ -50,6 +51,7 @@ export class HomepodRadioPlatformConfig {
 
         this.enableVolumeControl = (this.config.enableVolumeControl ??= false);
         this.volume = this.config.volume || 25;
+        this.keepConnectionWarm = (this.config.keepConnectionWarm ??= false);
 
         this.loadRadioConfigs();
         this.loadAudioConfigs();

--- a/src/platformConfig.ts
+++ b/src/platformConfig.ts
@@ -1,6 +1,6 @@
 import { PlatformConfig } from 'homebridge';
 
-import { PLUGIN_MODEL } from './platformConstants.js';
+import { PLUGIN_MODEL, DEFAULT_KEEP_CONNECTION_WARM } from './platformConstants.js';
 
 export interface RadioConfig {
     name: string;
@@ -51,7 +51,8 @@ export class HomepodRadioPlatformConfig {
 
         this.enableVolumeControl = (this.config.enableVolumeControl ??= false);
         this.volume = this.config.volume || 25;
-        this.keepConnectionWarm = (this.config.keepConnectionWarm ??= false);
+        // On by default; an explicit config value (true/false) still wins.
+        this.keepConnectionWarm = this.config.keepConnectionWarm ?? DEFAULT_KEEP_CONNECTION_WARM;
 
         this.loadRadioConfigs();
         this.loadAudioConfigs();

--- a/src/platformConstants.ts
+++ b/src/platformConstants.ts
@@ -4,3 +4,10 @@ export const PLUGIN_NAME = '@homebridge-plugins/homebridge-homepod-radio';
 export const PLUGIN_MANUFACTURER = 'petro-kushchak';
 
 export const PLUGIN_MODEL = 'Homepod Radio';
+
+// Internal default for the warm-connection feature. The feature is on by
+// default and only consumes resources when at least one audio button is
+// configured (see platform.ts). It can still be opted out per-install by
+// setting "keepConnectionWarm": false in config.json; flip this constant (or
+// re-expose the option in config.schema.json) to change the default behavior.
+export const DEFAULT_KEEP_CONNECTION_WARM = true;


### PR DESCRIPTION
Adds an **opt-in** `keepConnectionWarm` option that keeps a single resident pyatv
connection open and reuses it for audio-file buttons, eliminating the multi-second
cold-start delay on each press. Default is `false`, so existing setups are
completely unaffected.

## Why?

Today every audio-file button press goes through `airplayDevice.playFile()`, which
spawns a fresh `python3` helper:

```ts
this.streaming = child.spawn('python3', [scriptPath, '--id', homepodId, '--file', filePath, ...]);
```

Each spawn re-pays the full `import pyatv` cold start plus a device scan/connect
before any audio plays. For short sound effects (door chimes, alerts, ringtones)
that startup cost dominates the perceived latency (eg on a cheap RPi Zero 2 W it's roughly **5 seconds of dead air** before a ~2 second clip is heard)

## What this adds

- **`keepConnectionWarm`** boolean config option (default `false`).
- A resident pyatv worker (`bin/warm-worker.py`) that imports pyatv once and holds
  the AirPlay connection open for the life of the plugin.
- A small supervisor (`src/lib/warmPlayer.ts`) that starts the worker on
  `didFinishLaunching` (only when the toggle is on **and** at least one `audioFiles`
  entry exists), restarts it with backoff if it exits, and tears it down on
  shutdown.
- `playFile()` now prefers the warm worker when it is ready and **falls back to the
  existing spawn path** if the worker is down — so a worker failure can never
  silently break a button.

## How it works

```
didFinishLaunching ──> (keepConnectionWarm && audioFiles.length) ──> WarmPlayer.start()
                                                                         │
button press ──> playFile() ──> worker ready? ──┬─ yes ─> stdin JSON play cmd (warm)
                                                └─ no  ─> spawn python3 stream.py (existing)
```

The worker speaks a tiny newline-delimited JSON protocol over stdin/stdout
(`ping` / `play`), mirroring the same pyatv `scan → connect → stream_file` core the
plugin already uses, so there is no new playback behavior — only connection reuse.

## Backwards compatibility

- Fully opt-in; the default (`false`) preserves the current spawn-per-press
  behavior exactly.
- No changes to the webhook (`/play/...`) path — it intentionally still uses the
  standard path (documented in the README). Only an opt-in improvement to HomeKit **audio-file switch** type accessories.
- No new runtime npm dependencies. The worker ships the same way `stream.py` does
  (via the existing `bin/* -> dist` copy step).

## Testing

Validated on a Raspberry Pi Zero 2 W (Bookworm, Node 24, pyatv 0.16.0) against a
HomePod Mini:

- With `keepConnectionWarm: false`: behavior unchanged.
- With `keepConnectionWarm: true`: worker reaches a warm/ready state at launch;
  subsequent button presses skip the cold start and play noticeably sooner. The
  per-press `import pyatv` + scan cost is eliminated (paid once at startup).
- Worker crash → automatic restart with backoff; presses during downtime fall back
  to the spawn path and still play.
- `npm run lint` and `npm run build` pass.

## DevNote

Hey, it's my first PR to your repo, big fan of your work, this runs multiple times a week on my setup. Let me know anything I can improve upon this PR if you find it useful to incorporate. -- C
