### PR TITLE
fix: stop warm worker restart loop and surface pyatv import failure (#350)

### DIFF
--- a/bin/warm-worker.py
+++ b/bin/warm-worker.py
@@ -29,9 +29,16 @@ import os
 import re
 import sys
 
-import pyatv
-from pyatv.const import Protocol
-from pyatv.interface import MediaMetadata
+try:
+    import pyatv
+    from pyatv.const import Protocol
+    from pyatv.interface import MediaMetadata
+    _PYATV_IMPORT_ERROR = None
+except ImportError as ex:
+    pyatv = None
+    Protocol = None
+    MediaMetadata = None
+    _PYATV_IMPORT_ERROR = ex
 
 
 _LOGGER = logging.getLogger("warm-worker")
@@ -197,6 +204,11 @@ def main() -> None:
         datefmt="%Y-%m-%d %H:%M:%S",
         format="%(asctime)s %(levelname)s [%(name)s]: %(message)s",
     )
+
+    if _PYATV_IMPORT_ERROR is not None:
+        _LOGGER.error("Required dependency 'pyatv' was not found. Install it with: pip3 install pyatv")
+        _LOGGER.error("Import error: %s", _PYATV_IMPORT_ERROR)
+        sys.exit(1)
 
     try:
         asyncio.run(main_async(args.id))

--- a/src/lib/warmPlayer.ts
+++ b/src/lib/warmPlayer.ts
@@ -28,9 +28,12 @@ export class WarmPlayer {
     private rl: readline.Interface | undefined;
     private ready = false;
     private stopped = false;
+    private restartDisabled = false;
 
     private restartDelay = 1000;
     private readonly MAX_RESTART_DELAY = 30000;
+    private restartAttempts = 0;
+    private readonly MAX_RESTART_ATTEMPTS = 6;
     private readonly PLAY_TIMEOUT_MS = 60000;
 
     private nextId = 1;
@@ -51,7 +54,7 @@ export class WarmPlayer {
     }
 
     public start(): void {
-        if (this.stopped || this.worker) {
+        if (this.stopped || this.restartDisabled || this.worker) {
             return;
         }
 
@@ -59,7 +62,7 @@ export class WarmPlayer {
         if (this.verboseMode) {
             args.push('--verbose');
         }
-        this.logger.info(`[warm] starting worker: python3 ${args.join(' ')}`);
+        this.logger.info(`Starting warm worker: python3 ${args.join(' ')}`);
 
         this.worker = child.spawn('python3', args, { env: { ...process.env } });
 
@@ -67,15 +70,15 @@ export class WarmPlayer {
         this.rl.on('line', (line) => this.handleLine(line));
 
         this.worker.stderr!.on('data', (data) => {
-            this.debug(`[warm worker] ${data.toString().trim()}`);
+            this.logWorkerStderr(data.toString());
         });
 
         this.worker.on('error', (err) => {
-            this.logger.error(`[warm] worker spawn error: ${err}`);
+            this.logger.error(`Warm worker spawn error: ${err}`);
         });
 
         this.worker.on('exit', (code, signal) => {
-            this.logger.warn(`[warm] worker exited code=${code} signal=${signal}`);
+            this.logger.warn(`Warm worker exited code=${code} signal=${signal}`);
             this.ready = false;
             this.rl?.close();
             this.rl = undefined;
@@ -83,6 +86,21 @@ export class WarmPlayer {
             this.failAllPending();
             this.scheduleRestart();
         });
+    }
+
+    private logWorkerStderr(output: string): void {
+        const lines = output
+            .split(/\r?\n/)
+            .map((line) => line.trim())
+            .filter((line) => line.length > 0);
+
+        for (const line of lines) {
+            if (/traceback|error|exception|module not found/i.test(line)) {
+                this.logger.error(`Warm worker: ${line}`);
+            } else {
+                this.logger.warn(`Warm worker: ${line}`);
+            }
+        }
     }
 
     private handleLine(line: string): void {
@@ -95,14 +113,15 @@ export class WarmPlayer {
         try {
             msg = JSON.parse(trimmed);
         } catch {
-            this.debug(`[warm] non-JSON from worker: ${trimmed}`);
+            this.debug(`Warm worker non-JSON output: ${trimmed}`);
             return;
         }
 
         if (msg.event === 'ready') {
             this.ready = true;
             this.restartDelay = 1000; // healthy start resets backoff
-            this.logger.info('[warm] worker ready (connection held warm)');
+            this.restartAttempts = 0;
+            this.logger.info('Warm worker ready (connection held warm)');
             return;
         }
 
@@ -113,7 +132,7 @@ export class WarmPlayer {
                 clearTimeout(pending.timer);
                 this.pending.delete(key);
                 if (msg.ok === false && msg.error) {
-                    this.logger.warn(`[warm] play failed: ${msg.error}`);
+                    this.logger.warn(`Warm play failed: ${msg.error}`);
                 }
                 pending.resolve(msg.ok === true);
             }
@@ -124,9 +143,19 @@ export class WarmPlayer {
         if (this.stopped) {
             return;
         }
+        this.restartAttempts += 1;
+        if (this.restartAttempts > this.MAX_RESTART_ATTEMPTS) {
+            this.restartDisabled = true;
+            this.logger.error(
+                `Warm worker failed to start after ${this.MAX_RESTART_ATTEMPTS} attempts; disabling warm connection until Homebridge restarts`,
+            );
+            return;
+        }
         const delay = this.restartDelay;
         this.restartDelay = Math.min(this.restartDelay * 2, this.MAX_RESTART_DELAY);
-        this.logger.info(`[warm] restarting worker in ${delay}ms`);
+        this.logger.info(
+            `Restarting warm worker in ${delay}ms (attempt ${this.restartAttempts}/${this.MAX_RESTART_ATTEMPTS})`,
+        );
         setTimeout(() => this.start(), delay);
     }
 
@@ -158,7 +187,7 @@ export class WarmPlayer {
         return new Promise<boolean>((resolve) => {
             const timer = setTimeout(() => {
                 this.pending.delete(id);
-                this.logger.warn(`[warm] play timed out for ${filePath}`);
+                this.logger.warn(`Warm play timed out for ${filePath}`);
                 resolve(false);
             }, this.PLAY_TIMEOUT_MS);
 
@@ -169,7 +198,7 @@ export class WarmPlayer {
             } catch (err) {
                 clearTimeout(timer);
                 this.pending.delete(id);
-                this.logger.warn(`[warm] failed to write to worker: ${err}`);
+                this.logger.warn(`Failed to write to warm worker: ${err}`);
                 resolve(false);
             }
         });


### PR DESCRIPTION
## Summary

Fixes #350.

The warm worker could exit repeatedly with `code=1 signal=null` and then restart **forever** with no actionable log output. When the failure cause is permanent (e.g. `pyatv` not importable in the interpreter Homebridge invokes), the old behavior was an endless 30 s-interval restart loop that never surfaced *why* the worker was dying.

This change makes the warm worker fail loudly, fail finitely, and degrade gracefully.

## Changes

**`bin/warm-worker.py`**
- Wrap the `pyatv` imports in a `try/except ImportError` guard. If `pyatv` is not importable, log an actionable error (`Required dependency 'pyatv' was not found. Install it with: pip3 install pyatv`) plus the underlying import error, then `sys.exit(1)` cleanly instead of dying with an unhandled `ModuleNotFoundError` traceback.

**`src/lib/warmPlayer.ts`**
- **Cap restart attempts at 6.** After the 6th failed start, set `restartDisabled` and log `Warm worker failed to start after 6 attempts; disabling warm connection until Homebridge restarts`, then stop retrying. Playback automatically falls back to the existing per-press cold-spawn path, so audio still works.
- **Forward worker stderr to the Homebridge log.** New `logWorkerStderr` surfaces tracebacks/errors from the Python worker at `error` level (and other lines at `warn`), so the root cause is visible without enabling verbose mode.
- **Reset the attempt counter on a healthy `ready`**, so a worker that recovers gets a fresh budget.
- **Logging cleanup** (per review feedback): removed the noisy `[warm]` prefix from every message and switched to sentence-case wording (`Starting warm worker…`, `Restarting warm worker in {delay}ms (attempt n/6)`, `Warm worker exited…`, etc.).

## Reviewer requests addressed

- [x] Logs show what the error is (actionable `pyatv` message + forwarded worker stderr)
- [x] Worker stops trying after ~6 attempts instead of looping endlessly
- [x] Removed the `[warm]` prefix from log output
- [x] Capitalized / sentence-cased log output

## Validation

Verified on a Raspberry Pi running Homebridge with the plugin deployed as an isolated side-by-side instance, so the stock and existing builds were untouched.

Reproduced the exact reported failure by making `pyatv` unimportable for the worker only:

```
Starting warm worker: python3 -u .../warm-worker.py --id <id>
Warm worker: ERROR [warm-worker]: Required dependency 'pyatv' was not found. Install it with: pip3 install pyatv
Warm worker: ERROR [warm-worker]: Import error: import of pyatv halted; None in sys.modules
Warm worker exited code=1 signal=null
Restarting warm worker in 2000ms (attempt 2/6)
... (backoff 1s → 2s → 4s → 8s → 16s → 30s) ...
Restarting warm worker in 30000ms (attempt 6/6)
Warm worker exited code=1 signal=null
Warm worker failed to start after 6 attempts; disabling warm connection until Homebridge restarts
```

Confirmed:
- The loop stops after attempt 6 (no further worker processes spawned).
- The actionable `pyatv` error is logged on every attempt.
- After clearing the fault and restarting Homebridge, the worker returns to `Warm worker ready (connection held warm)`.
