### PR TITLE
fix: clean up warm worker restart logging (#353)

### DIFF
--- a/src/lib/warmPlayer.ts
+++ b/src/lib/warmPlayer.ts
@@ -32,8 +32,8 @@ export class WarmPlayer {
 
     private restartDelay = 1000;
     private readonly MAX_RESTART_DELAY = 30000;
-    private restartAttempts = 0;
-    private readonly MAX_RESTART_ATTEMPTS = 6;
+    private startAttempts = 0;
+    private readonly MAX_START_ATTEMPTS = 3;
     private readonly PLAY_TIMEOUT_MS = 60000;
 
     private nextId = 1;
@@ -58,11 +58,15 @@ export class WarmPlayer {
             return;
         }
 
+        this.startAttempts += 1;
+
         const args = ['-u', this.scriptPath, '--id', this.homepodId];
         if (this.verboseMode) {
             args.push('--verbose');
         }
-        this.logger.info(`Starting warm worker: python3 ${args.join(' ')}`);
+        this.logger.info(
+            `Starting warm worker (attempt ${this.startAttempts}/${this.MAX_START_ATTEMPTS}): python3 ${args.join(' ')}`,
+        );
 
         this.worker = child.spawn('python3', args, { env: { ...process.env } });
 
@@ -94,7 +98,28 @@ export class WarmPlayer {
             .map((line) => line.trim())
             .filter((line) => line.length > 0);
 
+        // The worker logs to stderr as "<date> <time> <LEVEL> [warm-worker]: <message>".
+        // Strip that prefix so Homebridge doesn't double-stamp it, and route by the
+        // worker's own level instead of guessing from keywords.
+        const prefix =
+            /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\s+(DEBUG|INFO|WARNING|ERROR|CRITICAL)\s+\[[^\]]*\]:\s*(.*)$/;
+
         for (const line of lines) {
+            const match = prefix.exec(line);
+            if (match) {
+                const [, level, message] = match;
+                if (level === 'ERROR' || level === 'CRITICAL') {
+                    this.logger.error(`Warm worker: ${message}`);
+                } else if (level === 'WARNING') {
+                    this.logger.warn(`Warm worker: ${message}`);
+                } else {
+                    this.debug(`Warm worker: ${message}`);
+                }
+                continue;
+            }
+
+            // Lines without the worker's standard prefix (e.g. raw traceback
+            // continuation lines): fall back to a keyword heuristic.
             if (/traceback|error|exception|module not found/i.test(line)) {
                 this.logger.error(`Warm worker: ${line}`);
             } else {
@@ -120,7 +145,7 @@ export class WarmPlayer {
         if (msg.event === 'ready') {
             this.ready = true;
             this.restartDelay = 1000; // healthy start resets backoff
-            this.restartAttempts = 0;
+            this.startAttempts = 0;
             this.logger.info('Warm worker ready (connection held warm)');
             return;
         }
@@ -143,18 +168,18 @@ export class WarmPlayer {
         if (this.stopped) {
             return;
         }
-        this.restartAttempts += 1;
-        if (this.restartAttempts > this.MAX_RESTART_ATTEMPTS) {
+        const nextAttempt = this.startAttempts + 1;
+        if (nextAttempt > this.MAX_START_ATTEMPTS) {
             this.restartDisabled = true;
             this.logger.error(
-                `Warm worker failed to start after ${this.MAX_RESTART_ATTEMPTS} attempts; disabling warm connection until Homebridge restarts`,
+                `Warm worker failed to start after ${this.MAX_START_ATTEMPTS} attempts; disabling warm connection until Homebridge restarts`,
             );
             return;
         }
         const delay = this.restartDelay;
         this.restartDelay = Math.min(this.restartDelay * 2, this.MAX_RESTART_DELAY);
         this.logger.info(
-            `Restarting warm worker in ${delay}ms (attempt ${this.restartAttempts}/${this.MAX_RESTART_ATTEMPTS})`,
+            `Restarting warm worker in ${delay}ms (attempt ${nextAttempt}/${this.MAX_START_ATTEMPTS})`,
         );
         setTimeout(() => this.start(), delay);
     }


### PR DESCRIPTION
## Summary

Follow-up to #350 / #351, addressing the log-cleanup feedback in #353. The warm-worker restart logic now produces cleaner, more accurate logs.

Fixes #353

## Changes

### 1. Strip the worker's own log prefix from forwarded stderr
The Python worker logs to stderr with its own `YYYY-MM-DD HH:MM:SS LEVEL [warm-worker]:` prefix. The plugin was forwarding that line verbatim and Homebridge then added *its* own timestamp + platform prefix, so every worker line was double-stamped. `logWorkerStderr()` now strips the worker's prefix and routes the message by the worker's **actual** log level instead of guessing from keywords. Lines without the standard prefix (e.g. raw traceback continuation lines) still fall back to the keyword heuristic.

**Before**
```
[6/2/2026, 7:29:06 PM] [BigPod Platform] Warm worker: 2026-06-02 19:29:06 ERROR [warm-worker]: Required dependency 'pyatv' was not found. Install it with: pip3 install pyatv
[6/2/2026, 7:29:06 PM] [BigPod Platform] Warm worker: 2026-06-02 19:29:06 ERROR [warm-worker]: Import error: No module named 'pyatv'
```
**After**
```
[6/2/2026, 7:29:06 PM] [BigPod Platform] Warm worker: Required dependency 'pyatv' was not found. Install it with: pip3 install pyatv
[6/2/2026, 7:29:06 PM] [BigPod Platform] Warm worker: Import error: No module named 'pyatv'
```

### 2. Fix the attempt counter off-by-one
The initial spawn is now counted and logged as `attempt 1/N`, and restarts are numbered from 2 onward, so the logged attempt count matches reality.

```
[BigPod Platform] Starting warm worker (attempt 1/3): python3 -u .../warm-worker.py --id BigPod
<failure errors>
[BigPod Platform] Restarting warm worker in 1000ms (attempt 2/3)
[BigPod Platform] Starting warm worker (attempt 2/3): python3 -u .../warm-worker.py --id BigPod
...
```

### 3. Lower the restart cap from 6 to 3
A missing dependency or a persistent network fault will not resolve itself, so retrying six times just delays the inevitable. Three attempts is enough before disabling the warm connection until Homebridge restarts.

## Testing
- `npm run build` / `tsc --noEmit` — clean
- `eslint src/lib/warmPlayer.ts` — clean
- Validated on a side-by-side Homebridge instance against a HomePod: the import-failure path now logs three single-stamped attempts and then disables the warm connection; cold-spawn fallback playback continues to work.
