### PR TITLE
fix: size warm-play timeout to track duration (#360)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,9 +26,8 @@ jobs:
       - name: Lint the project
         run: npm run lint
 
-      # Comment out temporarily
-      #- name: Run tests
-      #  run: npm test
+      - name: Run unit tests
+        run: npm test
 
       - name: Build the project
         run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -119,5 +119,9 @@ dist
 .yarn/build-state.yml
 .pnp.*
 
+# Python bytecode (warm-worker.py / stream.py and their tests)
+__pycache__/
+*.py[cod]
+
 **/.DS_Store
 .idea

--- a/README.md
+++ b/README.md
@@ -191,6 +191,12 @@ Notes:
   button.
 - The first press after restart may still be slightly slower while the worker
   finishes its initial warm-up.
+- The warm worker sizes its internal playback timeout to the actual length of
+  the audio (or playlist) being streamed, so tracks longer than a minute play in
+  full. `.wav` durations are read with Python's built-in `wave` module; for
+  `.mp3`, `.flac`, and `.ogg` install the optional `mutagen` package (see
+  [Dependencies](#dependencies)) so the length can be measured exactly. Without
+  it, non-`.wav` tracks fall back to a generous default timeout.
 
 ### Webhook for audio file playback
 
@@ -264,6 +270,27 @@ Make atvremote available for homebridge:
 ```
 sudo ln -s /home/pi/.local/bin/atvremote /usr/local/bin/atvremote
 ```
+
+### Optional: mutagen (accurate warm-play timeouts)
+
+When the warm connection is enabled (the default), the plugin sizes each play's
+internal timeout to the real length of the audio so tracks longer than a minute
+are not cut off mid-playback. `.wav` files are measured with Python's built-in
+`wave` module, but `.mp3`, `.flac`, and `.ogg` files need the lightweight,
+pure-Python [`mutagen`](https://mutagen.readthedocs.io/) package (no ffmpeg
+required):
+```
+pip3 install mutagen
+```
+If the install fails with `externally-managed-environment`, add the
+`--break-system-packages` option:
+```
+pip3 install mutagen --break-system-packages
+```
+`mutagen` is optional: without it, non-`.wav` tracks simply fall back to a
+generous default timeout instead of an exact one. In the Homebridge Docker
+container, add the same `pip3 install mutagen --break-system-packages` line to
+`startup.sh` next to `pyatv` so it survives container recreation.
 
 ### Installing the PyATV lib in the Homebridge Docker container
 

--- a/bin/test_warm_worker.py
+++ b/bin/test_warm_worker.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Unit tests for the duration helpers in ``warm-worker.py``.
+
+These cover the audio-length measurement that sizes the warm-play timeout — the
+core of the issue #360 fix. They use only the standard library: a real ``.wav``
+is generated with the stdlib ``wave`` module, so the exact-measurement path is
+exercised without mutagen, ffmpeg, pyatv, or any committed audio fixture.
+
+Run:  python3 -m unittest discover -s bin -p 'test_*.py'
+"""
+import importlib.util
+import os
+import tempfile
+import unittest
+import wave
+
+# ``warm-worker.py`` is not an importable module name (hyphen), so load it by
+# path. pyatv and mutagen imports inside it are guarded, so this succeeds with
+# only the standard library installed.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_SPEC = importlib.util.spec_from_file_location(
+    "warm_worker", os.path.join(_HERE, "warm-worker.py"),
+)
+warm_worker = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(warm_worker)
+
+
+def _write_wav(path, seconds, framerate=8000):
+    """Write a silent mono 16-bit WAV of the given length."""
+    frames = int(seconds * framerate)
+    with wave.open(path, "wb") as wav:
+        wav.setnchannels(1)
+        wav.setsampwidth(2)
+        wav.setframerate(framerate)
+        wav.writeframes(b"\x00\x00" * frames)
+
+
+class AudioDurationTests(unittest.TestCase):
+    def test_wav_duration_is_measured_via_stdlib(self):
+        with tempfile.TemporaryDirectory() as folder:
+            path = os.path.join(folder, "clip.wav")
+            _write_wav(path, 2.5)
+            self.assertAlmostEqual(warm_worker._audio_duration(path), 2.5, places=2)
+
+    def test_missing_file_reports_unknown(self):
+        self.assertIsNone(warm_worker._audio_duration("/no/such/file.wav"))
+
+    def test_unknown_format_without_mutagen_is_unknown(self):
+        # With mutagen absent, a non-wav file must report None so the supervisor
+        # uses its generous fallback instead of a too-short timeout.
+        if warm_worker._MutagenFile is not None:
+            self.skipTest("mutagen installed; unknown-format path not exercised")
+        with tempfile.TemporaryDirectory() as folder:
+            path = os.path.join(folder, "clip.mp3")
+            with open(path, "wb") as handle:
+                handle.write(b"not really an mp3")
+            self.assertIsNone(warm_worker._audio_duration(path))
+
+
+class TotalDurationTests(unittest.TestCase):
+    def test_sums_every_entry(self):
+        with tempfile.TemporaryDirectory() as folder:
+            first = os.path.join(folder, "a.wav")
+            second = os.path.join(folder, "b.wav")
+            _write_wav(first, 1.0)
+            _write_wav(second, 2.0)
+            self.assertAlmostEqual(warm_worker._total_duration([first, second]), 3.0, places=2)
+
+    def test_one_unknown_entry_makes_the_total_unknown(self):
+        # Deliberate: an underestimated total would re-introduce the premature
+        # timeout, so any unreadable entry forces the generous fallback.
+        with tempfile.TemporaryDirectory() as folder:
+            good = os.path.join(folder, "good.wav")
+            _write_wav(good, 1.0)
+            self.assertIsNone(warm_worker._total_duration([good, "/no/such.wav"]))
+
+
+class ExpandPlaylistTests(unittest.TestCase):
+    def test_non_playlist_path_passes_through(self):
+        self.assertEqual(warm_worker._expand_playlist("/tones/clip.wav"), ["/tones/clip.wav"])
+
+    def test_playlist_entries_resolve_against_the_playlist_folder(self):
+        with tempfile.TemporaryDirectory() as folder:
+            playlist = os.path.join(folder, "list.m3u")
+            with open(playlist, "w", encoding="UTF-8") as handle:
+                handle.write("# a comment\n")
+                handle.write("song-one.mp3\n")
+                handle.write("http://example.com/stream\n")
+                handle.write("song-two.mp3\n")
+            songs = warm_worker._expand_playlist(playlist)
+            self.assertEqual(
+                songs,
+                [os.path.join(folder, "song-one.mp3"), os.path.join(folder, "song-two.mp3")],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bin/warm-worker.py
+++ b/bin/warm-worker.py
@@ -14,6 +14,7 @@ Protocol (newline-delimited JSON; one object per line):
             {"id": "<id>", "cmd": "ping"}
 
     stdout  {"event": "ready"}                       (once, after startup)
+            {"id": "<id>", "event": "duration", "seconds": <float|null>}
             {"id": "<id>", "ok": true}
             {"id": "<id>", "ok": false, "error": "..."}
 
@@ -40,6 +41,15 @@ except ImportError as ex:
     MediaMetadata = None
     _PYATV_IMPORT_ERROR = ex
 
+try:
+    # Pure-Python audio metadata reader (no ffmpeg) used to size the play timeout
+    # to the real track length. Optional: when it is missing we still read .wav
+    # durations via the stdlib ``wave`` module and fall back to a generous timeout
+    # for other formats.
+    from mutagen import File as _MutagenFile
+except ImportError:
+    _MutagenFile = None
+
 
 _LOGGER = logging.getLogger("warm-worker")
 
@@ -48,6 +58,70 @@ def _out(obj) -> None:
     """Write one protocol message to stdout and flush immediately."""
     sys.stdout.write(json.dumps(obj) + "\n")
     sys.stdout.flush()
+
+
+def _expand_playlist(file_path: str):
+    """Expand an .m3u/.m3u8 playlist into a list of song paths (mirrors stream.py).
+
+    A non-playlist path is returned unchanged as a single-element list.
+    """
+    if file_path.endswith(".m3u") or file_path.endswith(".m3u8"):
+        folder = os.path.dirname(file_path)
+        with open(file_path, "r", encoding="UTF-8") as playlist:
+            lines = [ln.strip() for ln in playlist if ln.strip()]
+        return [
+            os.path.join(folder, ln)
+            for ln in lines
+            if re.match(r"^[A-Za-z0-9]", ln)
+            and not re.match(r"^[A-Za-z]:\\", ln)
+            and not re.match(r"^http[s]?://", ln)
+        ]
+    return [file_path]
+
+
+def _audio_duration(path: str):
+    """Best-effort duration in seconds of one audio file, or ``None`` if unknown.
+
+    Uses the stdlib ``wave`` module for ``.wav`` (always available) and
+    ``mutagen`` for mp3/flac/ogg and friends. ``mutagen`` is pure Python and does
+    not need ffmpeg; when it is not installed, non-wav files report ``None`` and
+    the supervisor falls back to a generous timeout.
+    """
+    try:
+        ext = os.path.splitext(path)[1].lower()
+        if ext == ".wav":
+            import wave
+
+            with wave.open(path, "rb") as wav:
+                rate = wav.getframerate()
+                if rate > 0:
+                    return wav.getnframes() / float(rate)
+            return None
+        if _MutagenFile is not None:
+            audio = _MutagenFile(path)
+            info = getattr(audio, "info", None) if audio is not None else None
+            length = getattr(info, "length", None) if info is not None else None
+            if length and length > 0:
+                return float(length)
+    except Exception as ex:  # noqa: BLE001 - duration is best-effort only
+        _LOGGER.debug("could not read duration of %s: %s", path, ex)
+    return None
+
+
+def _total_duration(songs):
+    """Total seconds across an expanded playlist, or ``None`` if any are unknown.
+
+    Returning ``None`` when even one file's length is unreadable is deliberate:
+    an underestimated total would re-introduce the premature-timeout bug, so we
+    prefer the supervisor's generous fallback in that case.
+    """
+    total = 0.0
+    for song in songs:
+        seconds = _audio_duration(song)
+        if seconds is None:
+            return None
+        total += seconds
+    return total
 
 
 class WarmConnection:
@@ -94,24 +168,14 @@ class WarmConnection:
                 pass
             self.atv = None
 
-    async def _expand(self, file_path: str):
-        # Mirror stream.py m3u/m3u8 handling so warm playback matches spawn.
-        if file_path.endswith(".m3u") or file_path.endswith(".m3u8"):
-            folder = os.path.dirname(file_path)
-            with open(file_path, "r", encoding="UTF-8") as playlist:
-                lines = [ln.strip() for ln in playlist if ln.strip()]
-            return [
-                os.path.join(folder, ln)
-                for ln in lines
-                if re.match(r"^[A-Za-z0-9]", ln)
-                and not re.match(r"^[A-Za-z]:\\", ln)
-                and not re.match(r"^http[s]?://", ln)
-            ]
-        return [file_path]
-
-    async def play(self, file_path: str, volume, title: str) -> None:
-        """Stream a file (or m3u) on the warm connection, reconnecting once on error."""
+    async def play(self, req_id, songs, volume, title: str) -> None:
+        """Stream pre-expanded songs on the warm connection, reconnecting once on error."""
         async with self._lock:
+            # Now that we hold the playback lock and are about to stream, tell the
+            # supervisor how long this will take. It sizes its watchdog timeout to
+            # the real audio length instead of a fixed 60s, which previously cut
+            # off (and then double-played via the spawn fallback) any longer track.
+            _out({"id": req_id, "event": "duration", "seconds": _total_duration(songs)})
             last_err = None
             for attempt in (1, 2):
                 try:
@@ -122,10 +186,10 @@ class WarmConnection:
                         except Exception as ex:  # noqa: BLE001
                             _LOGGER.warning("set_volume(%s) failed: %s", volume, ex)
                     metadata = MediaMetadata(title=title, album=title, artist=None, artwork=None)
-                    for song in await self._expand(file_path):
+                    for song in songs:
                         _LOGGER.info("streaming %s (attempt %d)", song, attempt)
                         await atv.stream.stream_file(song, metadata)
-                    _LOGGER.info("finished streaming %s", file_path)
+                    _LOGGER.info("finished streaming %d file(s)", len(songs))
                     return
                 except Exception as ex:  # noqa: BLE001
                     last_err = ex
@@ -181,7 +245,7 @@ async def main_async(identifier: str) -> None:
                 _out({"id": req_id, "ok": False, "error": "missing file"})
                 continue
             try:
-                await conn.play(file_path, volume, title)
+                await conn.play(req_id, _expand_playlist(file_path), volume, title)
                 _out({"id": req_id, "ok": True})
             except Exception as ex:  # noqa: BLE001
                 _out({"id": req_id, "ok": False, "error": str(ex)})

--- a/package.json
+++ b/package.json
@@ -38,8 +38,9 @@
     "lint": "eslint src/**.ts --max-warnings=0",
     "watch": "npm run build && npm link && nodemon",
     "build": "rimraf ./dist && tsc && npm run copy",
-    "copy": "cp bin/* dist",
+    "copy": "cp -R bin/* dist && rimraf dist/__pycache__",
     "e2e": "npm run build && node dist/e2e/test_e2e.js",
+    "test": "npm run build && node --test dist/test/*.test.js",
     "prepublishOnly": "npm run lint && npm run build"
   },
   "dependencies": {

--- a/src/lib/playTimeout.ts
+++ b/src/lib/playTimeout.ts
@@ -1,0 +1,34 @@
+/**
+ * Pure helper for sizing the warm-play watchdog timeout.
+ *
+ * Kept dependency-free (no homebridge / child_process imports) so the timeout
+ * logic that protects long tracks from a premature cut-off — the heart of the
+ * issue #360 fix — can be unit-tested in isolation.
+ */
+
+export interface WatchdogDecision {
+    /** Milliseconds to wait before the play is treated as timed out. */
+    timeoutMs: number;
+    /** True when the worker reported a usable (finite, positive) track length. */
+    known: boolean;
+}
+
+/**
+ * Size the warm-play watchdog for a track whose length the worker just reported.
+ *
+ * When the length is known the watchdog is that length plus headroom; otherwise
+ * it falls back to a deliberately generous cap so a legitimately long track is
+ * never cut off mid-playback (which previously also triggered a doubled play via
+ * the spawn fallback).
+ *
+ * @param seconds   Track length reported by the worker. Accepts any type; only a
+ *                  finite, positive number is treated as a known duration.
+ * @param paddingMs Headroom added on top of a known length.
+ * @param unknownMs Fallback timeout used when the length is unknown.
+ */
+export function computeWatchdog(seconds: unknown, paddingMs: number, unknownMs: number): WatchdogDecision {
+    const numeric = typeof seconds === 'number' ? seconds : NaN;
+    const known = Number.isFinite(numeric) && numeric > 0;
+    const timeoutMs = known ? Math.ceil(numeric * 1000) + paddingMs : unknownMs;
+    return { timeoutMs, known };
+}

--- a/src/lib/warmPlayer.ts
+++ b/src/lib/warmPlayer.ts
@@ -10,6 +10,7 @@ const __filename = fileURLToPath(import.meta.url);
 interface PendingRequest {
     resolve: (ok: boolean) => void;
     timer: ReturnType<typeof setTimeout>;
+    filePath: string;
 }
 
 /**
@@ -34,7 +35,16 @@ export class WarmPlayer {
     private readonly MAX_RESTART_DELAY = 30000;
     private startAttempts = 0;
     private readonly MAX_START_ATTEMPTS = 3;
-    private readonly PLAY_TIMEOUT_MS = 60000;
+    // How long to wait for the worker to even acknowledge a play request (with a
+    // duration estimate) before assuming it is wedged and falling back to spawn.
+    private readonly INITIAL_ACK_TIMEOUT_MS = 60000;
+    // Headroom added on top of the worker-reported track length before the
+    // watchdog fires, to absorb network jitter and AirPlay buffering.
+    private readonly PLAY_TIMEOUT_PADDING_MS = 30000;
+    // Fallback watchdog used when the worker cannot determine the audio length
+    // (e.g. mutagen is not installed for a non-wav file). Deliberately generous
+    // so a legitimately long track is never cut off mid-playback.
+    private readonly UNKNOWN_DURATION_TIMEOUT_MS = 30 * 60 * 1000;
 
     private nextId = 1;
     private readonly pending = new Map<string, PendingRequest>();
@@ -150,6 +160,13 @@ export class WarmPlayer {
             return;
         }
 
+        // The worker reports the track length once it actually starts streaming,
+        // so re-arm the watchdog to match instead of leaving the fixed start guard.
+        if (msg.event === 'duration' && msg.id !== undefined && msg.id !== null) {
+            this.applyPlayTimeout(String(msg.id), msg.seconds);
+            return;
+        }
+
         if (msg.id !== undefined && msg.id !== null) {
             const key = String(msg.id);
             const pending = this.pending.get(key);
@@ -157,11 +174,50 @@ export class WarmPlayer {
                 clearTimeout(pending.timer);
                 this.pending.delete(key);
                 if (msg.ok === false && msg.error) {
-                    this.logger.warn(`Warm play failed: ${msg.error}`);
+                    // The warm worker started successfully, so a stream failure is a
+                    // genuine error (not just a warning) even though we fall back.
+                    this.logger.error(`Warm play failed: ${msg.error}`);
                 }
                 pending.resolve(msg.ok === true);
             }
         }
+    }
+
+    /**
+     * Re-arm a pending play's watchdog once the worker reports how long the audio
+     * actually is. A fixed timeout would cut off — and then double-play via the
+     * spawn fallback — any track longer than the old 60s limit, so we size the
+     * timeout to the real duration plus headroom. When the length is unknown we
+     * fall back to a generous cap rather than a too-short fixed value.
+     */
+    private applyPlayTimeout(id: string, seconds: unknown): void {
+        const pending = this.pending.get(id);
+        if (!pending) {
+            return;
+        }
+        clearTimeout(pending.timer);
+        const numeric = typeof seconds === 'number' ? seconds : NaN;
+        const known = Number.isFinite(numeric) && numeric > 0;
+        const timeoutMs = known
+            ? Math.ceil(numeric * 1000) + this.PLAY_TIMEOUT_PADDING_MS
+            : this.UNKNOWN_DURATION_TIMEOUT_MS;
+        pending.timer = setTimeout(() => this.firePlayTimeout(id), timeoutMs);
+        const watchdogS = Math.round(timeoutMs / 1000);
+        if (known) {
+            this.debug(`Warm play watchdog set to ${watchdogS}s for ${pending.filePath} (track ~${Math.round(numeric)}s)`);
+        } else {
+            this.debug(`Warm play length unknown for ${pending.filePath}; using ${watchdogS}s fallback (install mutagen for exact timing)`);
+        }
+    }
+
+    private firePlayTimeout(id: string): void {
+        const pending = this.pending.get(id);
+        if (!pending) {
+            return;
+        }
+        this.pending.delete(id);
+        this.logger.error(`Warm play timed out for ${pending.filePath}`);
+        pending.resolve(false);
     }
 
     private scheduleRestart(): void {
@@ -210,13 +266,12 @@ export class WarmPlayer {
         const payload = JSON.stringify({ id, cmd: 'play', file: filePath, volume, title }) + '\n';
 
         return new Promise<boolean>((resolve) => {
-            const timer = setTimeout(() => {
-                this.pending.delete(id);
-                this.logger.warn(`Warm play timed out for ${filePath}`);
-                resolve(false);
-            }, this.PLAY_TIMEOUT_MS);
+            // Initial guard: the worker must acknowledge with a duration estimate
+            // within this window. Once it does, applyPlayTimeout() re-arms this
+            // timer to the actual track length so long tracks are not cut off.
+            const timer = setTimeout(() => this.firePlayTimeout(id), this.INITIAL_ACK_TIMEOUT_MS);
 
-            this.pending.set(id, { resolve, timer });
+            this.pending.set(id, { resolve, timer, filePath });
 
             try {
                 this.worker!.stdin!.write(payload);

--- a/src/lib/warmPlayer.ts
+++ b/src/lib/warmPlayer.ts
@@ -5,6 +5,8 @@ import * as path from 'path';
 import * as readline from 'readline';
 import { fileURLToPath } from 'url';
 
+import { computeWatchdog } from './playTimeout.js';
+
 const __filename = fileURLToPath(import.meta.url);
 
 interface PendingRequest {
@@ -196,17 +198,24 @@ export class WarmPlayer {
             return;
         }
         clearTimeout(pending.timer);
-        const numeric = typeof seconds === 'number' ? seconds : NaN;
-        const known = Number.isFinite(numeric) && numeric > 0;
-        const timeoutMs = known
-            ? Math.ceil(numeric * 1000) + this.PLAY_TIMEOUT_PADDING_MS
-            : this.UNKNOWN_DURATION_TIMEOUT_MS;
+        const { timeoutMs, known } = computeWatchdog(
+            seconds,
+            this.PLAY_TIMEOUT_PADDING_MS,
+            this.UNKNOWN_DURATION_TIMEOUT_MS,
+        );
         pending.timer = setTimeout(() => this.firePlayTimeout(id), timeoutMs);
         const watchdogS = Math.round(timeoutMs / 1000);
+        // Logged at info on purpose: issue #360 was a *silent* premature cut-off,
+        // so surfacing the chosen watchdog (once per play, matching the existing
+        // "Started/Finished file streaming" lines) is the breadcrumb needed to
+        // diagnose any future mis-sizing without enabling verbose mode.
         if (known) {
-            this.debug(`Warm play watchdog set to ${watchdogS}s for ${pending.filePath} (track ~${Math.round(numeric)}s)`);
+            const trackS = Math.round(seconds as number);
+            this.logger.info(`Warm play watchdog set to ${watchdogS}s for ${pending.filePath} (track ~${trackS}s)`);
         } else {
-            this.debug(`Warm play length unknown for ${pending.filePath}; using ${watchdogS}s fallback (install mutagen for exact timing)`);
+            this.logger.info(
+                `Warm play length unknown for ${pending.filePath}; using ${watchdogS}s fallback (install mutagen for exact timing)`,
+            );
         }
     }
 

--- a/src/test/playTimeout.test.ts
+++ b/src/test/playTimeout.test.ts
@@ -1,0 +1,43 @@
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+
+import { computeWatchdog } from '../lib/playTimeout.js';
+
+// Same constants the WarmPlayer uses, mirrored here so the test pins the real
+// behaviour rather than re-deriving it.
+const PADDING_MS = 30000;
+const UNKNOWN_MS = 30 * 60 * 1000;
+
+test('a known duration is sized to length + padding', () => {
+    const { timeoutMs, known } = computeWatchdog(73, PADDING_MS, UNKNOWN_MS);
+    assert.equal(known, true);
+    assert.equal(timeoutMs, 73000 + PADDING_MS);
+});
+
+test('fractional seconds round up to whole milliseconds before padding', () => {
+    const { timeoutMs, known } = computeWatchdog(73.13, PADDING_MS, UNKNOWN_MS);
+    assert.equal(known, true);
+    assert.equal(timeoutMs, Math.ceil(73.13 * 1000) + PADDING_MS);
+});
+
+test('a long (playlist-sized) total is never capped at the old 60s limit', () => {
+    const { timeoutMs } = computeWatchdog(600, PADDING_MS, UNKNOWN_MS);
+    assert.ok(timeoutMs > 60000, 'watchdog must exceed the old fixed 60s timeout');
+    assert.equal(timeoutMs, 600000 + PADDING_MS);
+});
+
+test('a 1s clip still uses the known path, not the fallback', () => {
+    const { timeoutMs, known } = computeWatchdog(1, PADDING_MS, UNKNOWN_MS);
+    assert.equal(known, true);
+    assert.equal(timeoutMs, 1000 + PADDING_MS);
+});
+
+// Anything that is not a finite, positive number must fall back to the generous
+// cap — an underestimate would re-introduce the premature-timeout bug (#360).
+for (const bad of [null, undefined, NaN, 0, -5, Infinity, '73', {}]) {
+    test(`unknown/invalid duration (${String(bad)}) uses the generous fallback`, () => {
+        const { timeoutMs, known } = computeWatchdog(bad, PADDING_MS, UNKNOWN_MS);
+        assert.equal(known, false);
+        assert.equal(timeoutMs, UNKNOWN_MS);
+    });
+}


### PR DESCRIPTION
Fixes #360.

## Problem

With `keepConnectionWarm` enabled, the warm worker used a **fixed 60s play
timeout** (`warmPlayer.ts`). Any audio file — or playlist — longer than a
minute hit that timeout *while it was still streaming successfully*. The
supervisor then treated the play as failed and fell back to the spawn path, so
the file was streamed to the HomePod **a second time** (the doubled playback
reported in the issue). In @justjam2013's case the file is a dynamically
generated `.wav` (weather + headlines) whose length varies, so a fixed timeout
can never be correct.

## Fix

The worker now measures the real audio length *before* streaming and reports it
to the supervisor, which sizes its watchdog to that length **plus headroom**
instead of a constant 60s:

- **`.wav`** → Python's built-in `wave` module (always available, so the exact
  scenario in the issue is fixed with no new dependency).
- **`.mp3` / `.flac` / `.ogg`** → the optional, pure-Python
  [`mutagen`](https://mutagen.readthedocs.io/) package (no ffmpeg). If it isn't
  installed those formats fall back to a generous default timeout rather than a
  too-short one — nothing breaks, the timeout just isn't exact.
- **Playlists (`.m3u` / `.m3u8`)** → the worker expands the playlist (as it
  already did for streaming) and **sums the duration of every entry**. That
  answers the second question in the issue: durations are added up + padding,
  not reset per file.

Protocol: the worker emits one new message right before it starts streaming —
`{"id", "event": "duration", "seconds": <float|null>}` — and the supervisor
re-arms the pending play's timer to `seconds + padding`, or a generous fallback
when `seconds` is `null`. An initial 60s acknowledgement guard still catches a
worker that never starts.

Per expectation #1 in the issue, a genuine warm-play **failure or timeout is now
logged at `error` level** (the worker initialised successfully, so a stream
failure is a real error, not just a warning).

## Notes / decisions

- `mutagen` is kept **optional** so existing installs don't break on upgrade;
  the README documents the one-line install and the Docker `startup.sh` note.
- Reading the duration worker-side (Python) keeps it next to the pyatv
  streaming code and matches the libraries suggested in the issue —
  `mutagen` + the stdlib `wave` module cover mp3/wav/flac/ogg with no ffmpeg
  requirement, so no Node dependency was added.

## Testing

- `npm run build` and `tsc --noEmit` — clean.
- `npm run lint` — no new violations (local-only CRLF noise from `core.autocrlf`;
  the committed blobs and CI are LF).
- Exercised the new helpers directly: a `.wav` is measured exactly, playlist
  totals are summed, and an unreadable / no-mutagen file correctly reports
  "unknown" so the supervisor uses its fallback timeout.

## On-device test (warm path)

Verified on real hardware, in addition to the synthetic checks above.

- **Device:** Raspberry Pi (`raspberrypi.local`), `Linux raspberrypi 6.12.87+rpt-rpi-v8 aarch64`, running Homebridge with this plugin and streaming to a HomePod (`CA3AB5A1AB1C`) over the warm `keepConnectionWarm` path.
- **Fixture:** a ~73s `.wav` played through an audio-file switch at `volume: 40`. `mutagen` was not installed, so this exercised the stdlib `wave` measurement path (the exact scenario from the issue).
- **Result:** the supervisor sized its watchdog from the measured length (`Warm play watchdog set to 103s ... track ~73s`) and the file streamed to completion (~77s wall clock, well past the old fixed 60s timeout) with no premature timeout, no fallback-to-spawn, and no doubled playback. The switch reset cleanly afterwards.